### PR TITLE
Update common.css - to have a closing cross on very top

### DIFF
--- a/src/style/common.css
+++ b/src/style/common.css
@@ -38,6 +38,7 @@
     right: 16px;
     width: 16px;
     height: 16px;
+    z-index: 9999;
 }
 
 .vodal-close:before,


### PR DESCRIPTION
add biggest `z-index` to closing element.
Because otherwise the cross may be visible but not clickable